### PR TITLE
component switch: when used inside .form, it breaks due to a conflict…

### DIFF
--- a/components/switch/scss/_main.scss
+++ b/components/switch/scss/_main.scss
@@ -16,6 +16,11 @@
     top: 9px;
     left: 10px;
     padding: 0;
+
+    &[type='checkbox']+label:before,
+    &[type='radio']+label:before{
+      display: none;
+    }
   }
   label {
     & {


### PR DESCRIPTION
… with radio/checkbox styles. BUG: switch grows wider with every click and the checkbox gets displayed next to it. FIX: hide checkbox/radio:before in switch css