### PR TITLE
Added data-fc-edit-type option to editable

### DIFF
--- a/components/form-editable/html/editable.html
+++ b/components/form-editable/html/editable.html
@@ -2,13 +2,11 @@
     <h4>value:</h4>
     <input id="valueId" />
     <br>
-    <div id='editable-div1' data-fc-modules="editable"  data-fc-mediator="channel:any" data-fc-tag="textarea" data-fc-class="any" data-fc-input-id="valueId">
-        some div here...
+    <br>
+    <div id='editable-div1' data-fc-modules="editable"  data-fc-mediator="channel:any" data-fc-tag="textarea" data-fc-class="any" data-fc-input-id="valueId" data-fc-edit-type="full">
+        some div here, click me...
     </div>
     <br>
-    <a onclick="$('#editable-div1').trigger('editable', {editable: true})">Editable=true</a>
-    <br>
-    <a onclick="$('#editable-div1').trigger('editable', {editable: false})">Editable=false</a>
     <br>
     <div id='editable-div2' data-fc-modules="editable"  data-fc-mediator="channel:any" data-fc-tag="input" data-fc-class="any" data-fc-input-id="valueId">
         another div here...

--- a/components/form-editable/js/editable.js
+++ b/components/form-editable/js/editable.js
@@ -3,7 +3,7 @@
 
 	FrontendCore.define('editable', [], function () {
 
-		//<div data-fc-modules="editable" data-fc-mediator="channel:any" data-fc-tag="textarea" data-fc-class="any" data-fc-input-id="myinput"></div>
+		//<div data-fc-modules="editable" data-fc-mediator="channel:any" data-fc-tag="textarea" data-fc-class="any" data-fc-input-id="myinput" data-fc-edit-type='full/click/focusout/none'></div>
 		var newElementIdPrefix = '_fc_editable_';
 
 		return {
@@ -20,6 +20,7 @@
 
 			},
 			autobind: function (oTarget, nIndex) {
+
 				$(oTarget).on('editable', function (event, data) {
 
 					if (data.editable === true) {
@@ -57,6 +58,16 @@
 
 						newElem.val($(oTarget).text().trim());
 
+
+						/*Prevent enter/submit when editable element is an input*/
+						if ( newElem.prop('tagName') == 'INPUT' ) {
+							$(oTarget).parent().on('keypress', newElem, function(event) {
+								if (event.keyCode == 13) {
+									event.preventDefault();
+								}
+							});
+						}
+
 						$(oTarget).parent().on('change', newElem, function() {
 							if (oTarget.getAttribute("data-fc-input-id") !== null) {
 								$('#' + oTarget.getAttribute("data-fc-input-id")).val(newElem.val());
@@ -66,6 +77,26 @@
 							}
 						});
 
+						$(oTarget).parent().on('focusout', newElem, function () {
+
+							var editType = oTarget.getAttribute("data-fc-edit-type");
+							if (editType === null)
+								return;
+
+							var isEditable = false;
+							if (oTarget.getAttribute("data-fc-editable-id") !== null) {
+								isEditable = true;
+							}
+
+							if (isEditable && (editType =='full' || editType =='focusout')) {
+								$(oTarget).trigger('editable', {editable: false});
+							}
+
+						});
+
+						if (data.focus === true) {
+							newElem.focus();
+						}
 					}
 					else {
 
@@ -90,6 +121,24 @@
 
 				});
 
+				$(oTarget).add($(oTarget).find('*')).on('click', function (event, data) {
+					event.preventDefault();
+					event.stopPropagation();
+
+					var editType = oTarget.getAttribute("data-fc-edit-type");
+					if (editType === null)
+						return;
+
+					var isEditable = false;
+					if (oTarget.getAttribute("data-fc-editable-id") !== null) {
+						isEditable = true;
+					}
+
+					if (!isEditable && (editType =='full' || editType =='click')) {
+						$(oTarget).trigger('editable', {editable: true, focus: true});
+					}
+
+				});
 
 			},
 		};

--- a/twig/forms/editable.html.twig
+++ b/twig/forms/editable.html.twig
@@ -17,7 +17,7 @@
     {
         "1" : {
             "name" :        "data-fc-mediator",
-            "description" : "[optional] Mediator event to publish new data when editable value is changed.",
+            "description" : "Mediator event to publish new data when editable value is changed.",
         },
         "2" : {
             "name" :        "data-fc-tag",
@@ -32,6 +32,11 @@
             "name" :        "data-fc-input-id",
             "description" : "If specified, value changes will also be stored on element with indicated ID.",
         },
+        "5" : {
+            "name" :        "data-fc-edit-type",
+            "description" : "Manages click/focusout events to automate editable state. 'full' => 'click' + 'focusout'. 'click' => When element is clicked, editable state is triggered automatically & element gets focus. 'focusout' => When element lost focus, not editable state is triggered automatically.",
+            "default" :     "none"
+        }
     }
     )}}
 {% endblock %}


### PR DESCRIPTION
On 'editable' component new option 'data-fc-edit-type' manages click/focusout events to automate editable state.
Now when data-fc-tag="input", editable input prevent enter key in order to avoid involuntary form submissions.
