### PR TITLE
Fix roundtrip async template XHR cache

### DIFF
--- a/components/roundtrip/js/_roundtrip.js
+++ b/components/roundtrip/js/_roundtrip.js
@@ -182,10 +182,9 @@
                 });
 
                 renderTemplate( sId, sData);
-
-                aIds.push(sId);
-
             });
+
+            aIds.push(sId);
         }
 
     };


### PR DESCRIPTION
All the TwigJS errors and duplicated XHR requests to templates were provoked by this misplaced push.